### PR TITLE
Remove PointDNS

### DIFF
--- a/platforms-and-services/3rd-party-services.md
+++ b/platforms-and-services/3rd-party-services.md
@@ -113,9 +113,7 @@ Exceptions:
 
 The only permitted DNS providers for Lambda School Labs projects are listed below:
 
-* Route53
-* PointDNS
-  * Only as required for Heroku deployments
+* AWS Route53
 
 All other services are prohibited from use.
 


### PR DESCRIPTION
No longer needed, all DNS should be handled by AWS Route53