### PR TITLE
Clarify AWS/Heroku platform usage

### DIFF
--- a/platforms-and-services/3rd-party-services.md
+++ b/platforms-and-services/3rd-party-services.md
@@ -30,6 +30,8 @@ The only permitted hosting providers for Lambda School Labs projects are listed 
 * Amazon Web Services \(AWS\)
   * See [AWS Standards](aws.md) for more detail
 * Heroku
+  * Web Backend Only
+  * See [Heroku Standards](heroku.md) for more detail
 
 All others are prohibited from use, including:
 


### PR DESCRIPTION
This makes it more clear that Heroku is only for web backends and adds a direct link to the Heroku standards.