### PR TITLE
adds dwolla to list of payment services

### DIFF
--- a/platforms-and-services/3rd-party-services.md
+++ b/platforms-and-services/3rd-party-services.md
@@ -4,8 +4,9 @@
 
 The only permitted code repositories for Lambda School Labs projects are listed below:
 
-* GitHub
-  * Specifically the [Lambda School Labs](https://github.com/Lambda-School-Labs)
+- GitHub
+
+  - Specifically the [Lambda School Labs](https://github.com/Lambda-School-Labs)
 
     organization
 
@@ -13,285 +14,286 @@ All others are prohibited from use.
 
 Rationale:
 
-* Lambda School Labs produces thousands of lines of code per week. It is essential that this code be centrally managed to provide safe-keeping for the code over time.
+- Lambda School Labs produces thousands of lines of code per week. It is essential that this code be centrally managed to provide safe-keeping for the code over time.
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-110\) Approved Hosting Providers
 
 The only permitted hosting providers for Lambda School Labs projects are listed below:
 
-* Amazon Web Services \(AWS\)
-  * See [AWS Standards](https://docs.labs.lambdaschool.com/standards/infrastructure/aws) for more detail
-* Heroku
-  * Web Backend Only
-  * See [Heroku Standards](https://docs.labs.lambdaschool.com/standards/infrastructure/heroku) for more detail
+- Amazon Web Services \(AWS\)
+  - See [AWS Standards](https://docs.labs.lambdaschool.com/standards/infrastructure/aws) for more detail
+- Heroku
+  - Web Backend Only
+  - See [Heroku Standards](https://docs.labs.lambdaschool.com/standards/infrastructure/heroku) for more detail
 
 All others are prohibited from use, including:
 
-* Firebase
-* Google Cloud Platform
-* Zeit
-* Netlify
+- Firebase
+- Google Cloud Platform
+- Zeit
+- Netlify
 
 Rationale:
 
-* We restrict hosting choices in Lambda Labs so that we can focus our resources on a subset of available providers. By narrowing the field of choices, we feel that product quality will be improved through the sharing of common knowledge and reusable components.
+- We restrict hosting choices in Lambda Labs so that we can focus our resources on a subset of available providers. By narrowing the field of choices, we feel that product quality will be improved through the sharing of common knowledge and reusable components.
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-120\) Approved Identity Providers
 
 The only permitted identity providers for Lambda School Labs projects are listed below:
 
-* Okta
+- Okta
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-130\) Approved CI/CD Platforms
 
 The only permitted CI/CD platforms for Lambda School Labs projects are listed below:
 
-* GitHub Actions
-* Native AWS Services
-* Native Heroku Services
+- GitHub Actions
+- Native AWS Services
+- Native Heroku Services
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-140\) Approved Domain Registrars
 
 The only permitted domain registration providers for Lambda School Labs projects are listed below:
 
-* Namecheap
-  * Only when provisioned using the Labs Tech Provisioning Process
+- Namecheap
+  - Only when provisioned using the Labs Tech Provisioning Process
 
 All other services are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-145\) Approved DNS Providers
 
 The only permitted DNS providers for Lambda School Labs projects are listed below:
 
-* AWS Route53
+- AWS Route53
 
 All other services are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-150\) Approved Online Payment Services
 
 The only permitted online payment processing for Lambda School Labs projects are listed below:
 
-* Stripe
+- [Stripe](https://stripe.com/docs)
+- [Dwolla](https://developers.dwolla.com/)
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- **For Dwolla Users** Be sure to work with our technical support specialist Kelly M.
 
 Alternatives:
 
-* None
+- Dwolla
 
 Exceptions:
 
-* None
+- Dwolla - When we have the ability to work hand-in-hand with a developer advocate from Dwolla, or when the stakeholder requires the use of this service for their app.
 
 ## \(TH-160\) Approved Text Messaging Services
 
 The only permitted text messaging for Lambda School Labs projects are listed below:
 
-* Twilio
+- Twilio
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-170\) Approved Email Services
 
 The only permitted email services for Lambda School Labs projects are listed below:
 
-* SendGrid
+- SendGrid
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-180\) Approved Mapping Services
 
 The only permitted mapping services for Lambda School Labs projects are listed below:
 
-* Google Maps
-* MapBox
+- Google Maps
+- MapBox
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-190\) Approved Mobile App Stores
 
 The only permitted mobile app stores for Lambda School Labs projects are listed below:
 
-* Google Play
-* Apple App Store
+- Google Play
+- Apple App Store
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-200\) Approved Code Quality Services
 
 The only permitted code quality services for Lambda School Labs projects are listed below:
 
-* CodeClimate
+- CodeClimate
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-210\) Approved User Analytics Services
 
 The only permitted user analytics services for Lambda School Labs projects are listed below:
 
-* [Google Analytics](https://analytics.google.com/)
-* [Mixpanel](https://mixpanel.com/)
-* [Segment](https://segment.com/) - may be used to route analytics calls to Google Analytics _and_ Mixpanel.
+- [Google Analytics](https://analytics.google.com/)
+- [Mixpanel](https://mixpanel.com/)
+- [Segment](https://segment.com/) - may be used to route analytics calls to Google Analytics _and_ Mixpanel.
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
+- None
 
 ## \(TH-220\) Approved Exception Monitoring Services
 
 The only permitted user analytics services for Lambda School Labs projects are listed below:
 
-* Sentry
+- Sentry
 
 All others are prohibited from use.
 
 Rationale:
 
-* Standardizing on a small number of services allows for students and staff to better share knowledge and code
+- Standardizing on a small number of services allows for students and staff to better share knowledge and code
 
 Alternatives:
 
-* None
+- None
 
 Exceptions:
 
-* None
-
+- None


### PR DESCRIPTION
- Per conversations we've had as a team, and with the technical support team/developer advocacy group over at Dwolla, this pull request adds [Dwolla](https://developers.dwolla.com/) to the list approved 3rd-party payment processes. 

- @misskellymore has agreed to work with student teams to get them set up in the Developer Sandbox and will provide support to teams looking to integrate with the platform. 
- Our potential 'launch date' for products in FT labs that will utilize payment processing and integrate with Dwolla won't be until June. 
- @misskellymore to author content in our Lambda Labs Guides. 